### PR TITLE
QWERTY keyboard piano trigger support

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,12 +1,13 @@
 {
-    "trailingComma": "es5",
-    "tabWidth": 4,
-    "semi": true,
-    "singleQuote": true,
-    "bracketSpacing": true,
-    "bracketSameLine": true,
-    "arrowParens": "always",
-    "endOfLine": "lf",
-    "embeddedLanguageFormatting": "auto",
-    "singleAttributePerLine": true
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "bracketSpacing": true,
+  "bracketSameLine": true,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "embeddedLanguageFormatting": "auto",
+  "singleAttributePerLine": true,
+  "useTabs": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,13 +1,13 @@
 {
-  "trailingComma": "es5",
-  "tabWidth": 2,
-  "semi": true,
-  "singleQuote": false,
-  "bracketSpacing": true,
-  "bracketSameLine": true,
-  "arrowParens": "always",
-  "endOfLine": "lf",
-  "embeddedLanguageFormatting": "auto",
-  "singleAttributePerLine": true,
-  "useTabs": true
+	"trailingComma": "es5",
+	"tabWidth": 4,
+	"semi": true,
+	"singleQuote": true,
+	"bracketSpacing": true,
+	"bracketSameLine": true,
+	"arrowParens": "always",
+	"endOfLine": "lf",
+	"embeddedLanguageFormatting": "auto",
+	"singleAttributePerLine": true,
+	"useTabs": false
 }

--- a/src/lib/components/global/TextInput.svelte
+++ b/src/lib/components/global/TextInput.svelte
@@ -15,6 +15,7 @@
     {placeholder}
     {disabled}
     on:input
+    on:keydown|stopPropagation
     bind:value />
 
 <style lang="scss">

--- a/src/lib/components/jam/Piano.svelte
+++ b/src/lib/components/jam/Piano.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { genPianoKeys, keyBindings } from '@lib/services/jam/piano';
-    import { NoteState, type MIDIMsg } from '@lib/types/jam';
+    import { NoteState, type MIDIMsg, type PianoKeyNote } from '@lib/types/jam';
     import { WSMsgTyp, type WSMsg } from '@lib/types/websocket';
     import { JamStore } from '@store/jam';
     import { PianoStore } from '@store/piano';

--- a/src/lib/components/jam/PianoKey.svelte
+++ b/src/lib/components/jam/PianoKey.svelte
@@ -1,103 +1,118 @@
 <script lang="ts">
-    import { AS, CS, DS, FS, GS } from '@lib/consts/piano';
-    import type { PianoKeyNote } from '@lib/types/jam';
-    import { PianoStore } from '@store/piano';
-    import { applyTheme, themeStore } from '@store/theme';
+	import { AS, CS, DS, FS, GS } from "@lib/consts/piano";
+	import type { KeyLabel, PianoKeyNote } from "@lib/types/jam";
+	import { PianoStore } from "@store/piano";
+	import { applyTheme, themeStore } from "@store/theme";
 
-    export let key: PianoKeyNote;
-    export let black: boolean;
+	export let key: PianoKeyNote;
+	export let black: boolean;
+	export let labelType: KeyLabel = "binding";
 
-    let keySpacing: number; // spacing for black keys only
-    switch (key.note) {
-        case CS:
-            keySpacing = 0;
-            break;
-        case DS:
-            keySpacing = 1;
-            break;
-        case FS:
-            keySpacing = 3;
-            break;
-        case GS:
-            keySpacing = 4;
-            break;
-        case AS:
-            keySpacing = 5;
-            break;
-    }
+	let keySpacing: number; // spacing for black keys only
+	switch (key.note) {
+		case CS:
+			keySpacing = 0;
+			break;
+		case DS:
+			keySpacing = 1;
+			break;
+		case FS:
+			keySpacing = 3;
+			break;
+		case GS:
+			keySpacing = 4;
+			break;
+		case AS:
+			keySpacing = 5;
+			break;
+	}
 
-    function handleKeyDown() {
-        $PianoStore = { keydown: true, currNote: key };
-    }
+	function handlePress() {
+		$PianoStore = { keydown: true, currNote: key };
+	}
 
-    function handleKeyEnter() {
-        if (!$PianoStore.keydown) {
-            return;
-        }
+	function handleKeyEnter() {
+		if (!$PianoStore.keydown) {
+			return;
+		}
 
-        $PianoStore.currNote = key;
-    }
+		$PianoStore.currNote = key;
+	}
 
-    let vars;
-    $: vars = $themeStore.vars;
+	function keyLabel(labelType: KeyLabel, key: PianoKeyNote): string {
+		switch (labelType) {
+			case "binding":
+				return key.binding?.keyName ?? "";
+			case "note":
+				return key.note.name[0];
+			case "midi":
+				return key.midi.toString();
+			default:
+				return key.note.name[0];
+		}
+	}
+
+	let vars;
+	$: vars = $themeStore.vars;
 </script>
 
 <div
-    on:mousedown={handleKeyDown}
-    on:mouseenter={handleKeyEnter}
-    on:focus
-    style={applyTheme(vars) +
-        `${black ? `left: ${keySpacing * 2.2 + 1 + 2 * 0.2}rem;` : ''}`}
-    class="key"
-    class:black
-    class:pressed={$PianoStore.currNote === key}>
-    <p>{key.note.name[0]}</p>
+	on:mousedown={handlePress}
+	on:mouseenter={handleKeyEnter}
+	on:focus
+	style={applyTheme(vars) +
+		`${black ? `left: ${keySpacing * 2.2 + 1 + 2 * 0.2}rem;` : ""}`}
+	class="key"
+	class:black
+	class:pressed={$PianoStore.currNote === key}>
+	<!-- TODO: Switch label type in settings -->
+	<p>{keyLabel("binding", key)}</p>
 </div>
 
 <style lang="scss">
-    .key {
-        width: 2rem;
-        height: 100%;
-        padding: 0.5rem;
-        margin: 0.1rem;
-        border-bottom-left-radius: 0.3rem;
-        border-bottom-right-radius: 0.3rem;
-        display: flex;
-        align-items: flex-end;
-        justify-content: center;
-        background-color: #fff;
-        box-shadow: var(--shadow);
-        transition: 0.3s ease;
-        cursor: pointer;
+	.key {
+		width: 2rem;
+		height: 100%;
+		padding: 0.5rem;
+		margin: 0.1rem;
+		border-bottom-left-radius: 0.3rem;
+		border-bottom-right-radius: 0.3rem;
+		display: flex;
+		align-items: flex-end;
+		justify-content: center;
+		background-color: #fff;
+		box-shadow: var(--shadow);
+		transition: 0.3s ease;
+		cursor: pointer;
 
-        p {
-            color: #000;
-            font-size: 1rem;
-        }
-    }
+		p {
+			color: #000;
+			font-size: 1rem;
+		}
+	}
 
-    .key:hover {
-        background-color: #aaa;
-    }
+	.key:hover {
+		background-color: #aaa;
+	}
 
-    .black {
-        position: absolute;
-        width: 1.5rem;
-        height: 60%;
-        margin: none;
-        background-color: #000;
+	.black {
+		position: absolute;
+		width: 1.5rem;
+		height: 60%;
+		margin: none;
+		background-color: #000;
 
-        p {
-            color: #fff;
-            font-size: 0.8rem;
-        }
-    }
+		p {
+			color: #fff;
+			font-size: 0.8rem;
+		}
+	}
 
-    .black:hover {
-        background-color: #333;
-    }
+	.black:hover {
+		background-color: #333;
+	}
 
-    .pressed {
-        box-shadow: none;
-    }
+	.pressed {
+		box-shadow: none;
+	}
 </style>

--- a/src/lib/services/jam/piano.ts
+++ b/src/lib/services/jam/piano.ts
@@ -16,7 +16,7 @@ const octaveNotes: PianoKeyNote[] = [
 	{ midi: 32, note: GS },
 ];
 
-const keyMap: KeyBinding[] = [
+export const keyBindings: KeyBinding[] = [
 	{ keyName: "a", isAccidental: false },
 	{ keyName: "w", isAccidental: true },
 	{ keyName: "s", isAccidental: false },
@@ -37,11 +37,17 @@ const keyMap: KeyBinding[] = [
 	{ keyName: "'", isAccidental: false },
 ];
 
-export function genPianoKeys(size: 49 | 61): PianoKeyNote[][] {
+export function genPianoKeys(
+	size: 49 | 61,
+	bindings: KeyBinding[]
+): {
+	keyMap: Record<KeyBinding["keyName"], number>;
+	keyboard: PianoKeyNote[][];
+} {
 	let notes: PianoKeyNote[] = [];
 	let startIdx: number;
 	let firstNoteMIDI: number;
-
+	const keyMap = {};
 	switch (size) {
 		case 49:
 			startIdx = 3;
@@ -61,28 +67,32 @@ export function genPianoKeys(size: 49 | 61): PianoKeyNote[][] {
 
 	firstNoteMIDI = 21 + startIdx;
 
-	for (let i, j = 0; i < size; i++) {
+	for (let i = 0, j = 0; i < size; i++) {
 		const { note } =
 			octaveNotes[((i % octaveNotes.length) + startIdx) % octaveNotes.length];
-
-		const n: PianoKeyNote & { binding?: KeyBinding } = {
-			midi: i + firstNoteMIDI,
+		const midi = i + firstNoteMIDI;
+		const n: PianoKeyNote = {
+			midi,
 			note,
 		};
+
 		if (note.name[0] === "C" && j == 0) {
 			j++;
 		}
-		if (j > 0 && j <= keyMap.length) {
-			n.binding = keyMap[j - 1];
+		if (j > 0 && j <= bindings.length) {
+			const binding = bindings[j - 1];
+			n.binding = binding;
+			keyMap[binding.keyName] = midi;
 			j++;
 		}
-
-		console.log(n);
 
 		notes.push(n);
 	}
 
-	return chunkBy(notes, octaveNotes.length);
+	return {
+		keyMap,
+		keyboard: chunkBy(notes, octaveNotes.length),
+	};
 }
 
 function chunkBy<T>(arr: T[], chunkSize: number): T[][] {

--- a/src/lib/services/jam/piano.ts
+++ b/src/lib/services/jam/piano.ts
@@ -1,5 +1,5 @@
-import { A, AS, B, C, CS, D, DS, E, F, FS, G, GS } from "@lib/consts/piano"
-import type { PianoKeyNote } from "@lib/types/jam";
+import { A, AS, B, C, CS, D, DS, E, F, FS, G, GS } from "@lib/consts/piano";
+import type { KeyBinding, PianoKeyNote } from "@lib/types/jam";
 
 const octaveNotes: PianoKeyNote[] = [
 	{ midi: 21, note: A },
@@ -14,10 +14,28 @@ const octaveNotes: PianoKeyNote[] = [
 	{ midi: 30, note: FS },
 	{ midi: 31, note: G },
 	{ midi: 32, note: GS },
-]
+];
 
-const blackMap = "wetyuop"
-const whiteMap = "asdfghjkl;'"
+const keyMap: KeyBinding[] = [
+	{ keyName: "a", isAccidental: false },
+	{ keyName: "w", isAccidental: true },
+	{ keyName: "s", isAccidental: false },
+	{ keyName: "e", isAccidental: true },
+	{ keyName: "d", isAccidental: false },
+	{ keyName: "f", isAccidental: false },
+	{ keyName: "t", isAccidental: true },
+	{ keyName: "g", isAccidental: false },
+	{ keyName: "y", isAccidental: true },
+	{ keyName: "h", isAccidental: false },
+	{ keyName: "u", isAccidental: true },
+	{ keyName: "j", isAccidental: false },
+	{ keyName: "k", isAccidental: false },
+	{ keyName: "o", isAccidental: true },
+	{ keyName: "l", isAccidental: false },
+	{ keyName: "p", isAccidental: true },
+	{ keyName: ";", isAccidental: false },
+	{ keyName: "'", isAccidental: false },
+];
 
 export function genPianoKeys(size: 49 | 61): PianoKeyNote[][] {
 	let notes: PianoKeyNote[] = [];
@@ -43,10 +61,25 @@ export function genPianoKeys(size: 49 | 61): PianoKeyNote[][] {
 
 	firstNoteMIDI = 21 + startIdx;
 
-	for (let i = 0; i < size; i++) {
-		const { note } = octaveNotes[((i % octaveNotes.length) + startIdx) % octaveNotes.length]
-		const n: PianoKeyNote = { midi: i + firstNoteMIDI, note }
-		notes.push(n)
+	for (let i, j = 0; i < size; i++) {
+		const { note } =
+			octaveNotes[((i % octaveNotes.length) + startIdx) % octaveNotes.length];
+
+		const n: PianoKeyNote & { binding?: KeyBinding } = {
+			midi: i + firstNoteMIDI,
+			note,
+		};
+		if (note.name[0] === "C" && j == 0) {
+			j++;
+		}
+		if (j > 0 && j <= keyMap.length) {
+			n.binding = keyMap[j - 1];
+			j++;
+		}
+
+		console.log(n);
+
+		notes.push(n);
 	}
 
 	return chunkBy(notes, octaveNotes.length);

--- a/src/lib/types/jam.ts
+++ b/src/lib/types/jam.ts
@@ -79,6 +79,7 @@ export interface Note {
 export interface PianoKeyNote {
 	midi: number;
 	note: Note;
+	binding?: KeyBinding;
 }
 
 export interface PianoState {
@@ -90,3 +91,5 @@ export type KeyBinding = {
 	keyName: string;
 	isAccidental: boolean;
 };
+
+export type KeyLabel = "note" | "midi" | "binding";

--- a/src/lib/types/jam.ts
+++ b/src/lib/types/jam.ts
@@ -44,8 +44,35 @@ export interface TextMsg {
 	body: string;
 }
 
+type NoteName =
+	| "A"
+	| "A#"
+	| "B"
+	| "C"
+	| "C#"
+	| "D"
+	| "D#"
+	| "E"
+	| "F"
+	| "F#"
+	| "G"
+	| "G#";
+type NoteSound =
+	| "La"
+	| "La#"
+	| "Ti"
+	| "Do"
+	| "Do#"
+	| "Re"
+	| "Re#"
+	| "Mi"
+	| "Fa"
+	| "Fa#"
+	| "So"
+	| "So#";
+
 export interface Note {
-	name: string[];
+	name: [NoteName, NoteSound];
 	black: boolean;
 }
 
@@ -58,3 +85,8 @@ export interface PianoState {
 	keydown?: boolean;
 	currNote?: PianoKeyNote;
 }
+
+export type KeyBinding = {
+	keyName: string;
+	isAccidental: boolean;
+};


### PR DESCRIPTION
Resolves #20 
Resolves #28 

Add keybindings for triggering piano

TODO:
- [ ] Add octave shift binding support
- [ ] Add settings for changing the piano key labels (show key binding, vs note name, vs MIDI number)

![image](https://user-images.githubusercontent.com/9354822/220457021-dab797a5-b0f9-4cb8-bedd-d80fda3296e2.png)


