### PR TITLE
Handle Out-of-bounds MIDI values

### DIFF
--- a/src/lib/services/jam/mic.test.ts
+++ b/src/lib/services/jam/mic.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { noteFromPitch } from './mic';
+
+describe('noteFromPitch()', () => {
+    const cases: { expectedMidi: number; pitch: number }[] = [
+        // Control
+        { pitch: 440, expectedMidi: 69 },
+        { pitch: 261.6, expectedMidi: 60 },
+        // Handle out of bounds frequencies
+        { pitch: 0, expectedMidi: null },
+        { pitch: 15_000, expectedMidi: null },
+        // Handle out of tune frequencies
+        { pitch: 8, expectedMidi: 0 },
+        { pitch: 21.533203125, expectedMidi: 17 },
+        { pitch: 43.06640625, expectedMidi: 29 },
+        { pitch: 64.599609375, expectedMidi: 36 },
+        { pitch: 86.1328125, expectedMidi: 41 },
+        { pitch: 129.19921875, expectedMidi: 48 },
+        { pitch: 258.3984375, expectedMidi: 60 },
+        { pitch: 753.662109375, expectedMidi: 78 },
+    ];
+    cases.forEach(({ expectedMidi, pitch }) => {
+        it(`should return MIDI: ${expectedMidi} for freq: ${pitch}hz`, () => {
+            const actual = noteFromPitch(pitch);
+            expect(actual).to.eq(expectedMidi);
+        });
+    });
+});

--- a/src/lib/services/jam/mic.ts
+++ b/src/lib/services/jam/mic.ts
@@ -75,12 +75,18 @@ function calcRMS(buf: Float32Array): number {
  * noteFromPitch(261.6) === 60 // Middle C
  * @param frequency hertz
  * @param octaveLength Number of notes in an octave. Defaults to 12.
- * @returns MIDI note number
  */
-export function noteFromPitch(frequency: number, octaveLength: number = 12) {
+export function noteFromPitch(
+    frequency: number,
+    octaveLength: number = 12
+): number | null {
     const A4 = { freq: 440, midi: 69 };
     var noteNum = octaveLength * (Math.log(frequency / A4.freq) / Math.log(2));
-    return Math.round(noteNum) + A4.midi;
+    const midiNote = Math.round(noteNum) + A4.midi;
+    if (midiNote < 0 || midiNote > 127) {
+        return null;
+    }
+    return midiNote;
 }
 
 /**


### PR DESCRIPTION
Update and test `noteFromPitch()` to return `null` if MIDI note value is less than `0` or above `127`. 